### PR TITLE
Small bug fix: adjust indentation from 3 whitespace to 4

### DIFF
--- a/python/bot/samples/command_and_control.py
+++ b/python/bot/samples/command_and_control.py
@@ -104,10 +104,10 @@ class RemoteConsole(CLIShell):
         self.transport.write("Network Failure: {}\n\n".format(e))
 
     def createObjectDisplay(self, objectData, indent=""):
-       s = ""
-       for key, value in objectData:
-           s += "{}{}: {}\n".format(indent, key, value)
-       return s 
+        s = ""
+        for key, value in objectData:
+            s += "{}{}: {}\n".format(indent, key, value)
+        return s
 
     def createScanResultsDisplay(self, scanResults):
         mapPart = ""


### PR DESCRIPTION
In Line 107 in command_and_control.py, the original indentation is 3 whitespace.