### PR TITLE
ADD feature 3 Robots cannot be placed in water, or on top of another robot

### DIFF
--- a/python/game/src/cyberwar/game.py
+++ b/python/game/src/cyberwar/game.py
@@ -211,7 +211,6 @@ class GameConsole(CLIShell):
         self._objectStore and self._objectStore.commit()
         # then we commit the database to file
         self._db and self._db.commit()
-        # Save the map.
         
     def autosave(self):
         self.saveGame()

--- a/python/game/src/cyberwar/game.py
+++ b/python/game/src/cyberwar/game.py
@@ -334,7 +334,7 @@ class GameConsole(CLIShell):
     
     def _createPlayerObject(self, startX, startY, objectType, brainType, *kargsList):
         kargs = {}
-        for argpair in kargsList:
+        for argpair in kargsList[0]:
             print(argpair)
             try:
                 k,v = argpair.split("=")
@@ -374,23 +374,25 @@ class GameConsole(CLIShell):
             return AttributeConstructor["mobile"](typeSection).waterAble()
 
     def _newPositonAvaliable(self, writer, x, y, objectType):
+        x, y = int(x), int(y)
         contentsResult = self._game.send(ContentsRequest("game", x, y))
         contents = contentsResult.Value
         terrainType = None
         otherObj = None
         for obj in contents:
             if isinstance(obj, Land):
-                terrainType = Land
+                terrainType = "land"
             elif isinstance(obj, Water):
-                terrainType = Water
+                terrainType = "water"
             elif isinstance(obj, ControlPlaneObject):
                 otherObj = obj
         if otherObj != None:
             writer("Target position is not avaliable. Other bots on this position.\n\n")
             return False
-        if terrainType == Water and self._getWaterAble(objectType) == 0:
+        if terrainType == "water" and self._getWaterAble(objectType) == 0:
             writer("Target position is not avaliable. {} can't place in water.\n\n".format(objectType))
             return False
+        # TODO: Add case that return false if the bot is water only and want to place on land.
         return True
 
     def _newGameObjectCommand(self, writer, x, y, objectType, *objectArgs):

--- a/python/game/src/cyberwar/game.py
+++ b/python/game/src/cyberwar/game.py
@@ -333,7 +333,7 @@ class GameConsole(CLIShell):
     
     def _createPlayerObject(self, startX, startY, objectType, brainType, *kargsList):
         kargs = {}
-        for argpair in kargsList[0]:
+        for argpair in kargsList:
             print(argpair)
             try:
                 k,v = argpair.split("=")
@@ -402,7 +402,7 @@ class GameConsole(CLIShell):
     def _newGameObjectCommand(self, writer, x, y, objectType, *objectArgs):
         if objectType in self._playerObjectTypes:
             if self._newPositonAvaliable(writer, x, y, objectType):
-                return self._newPlayerObjectCommand(writer, x, y, objectType, objectArgs[0], objectArgs[1:])
+                return self._newPlayerObjectCommand(writer, x, y, objectType, objectArgs[0], *objectArgs[1:])
         # TODO: Eventually, can have NPC's and other control plane objects.
         # But for now, only have brain controlled stuff.
         writer("Unknown object type {}\n".format(objectType))

--- a/python/game/src/cyberwar/game.py
+++ b/python/game/src/cyberwar/game.py
@@ -400,13 +400,6 @@ class GameConsole(CLIShell):
         # TODO: Eventually, can have NPC's and other control plane objects.
         # But for now, only have brain controlled stuff.
         writer("Unknown object type {}\n".format(objectType))
-
-    def _newGameObjectCommand(self, writer, x, y, objectType, *objectArgs):
-        if objectType in self._playerObjectTypes:
-            return self._newPlayerObjectCommand(writer, x, y, objectType, objectArgs[0], objectArgs[1:])
-        # TODO: Eventually, can have NPC's and other control plane objects.
-        # But for now, only have brain controlled stuff.
-        writer("Unknown object type {}\n".format(objectType))
         
     def _newPlayerObjectCommand(self, writer, x, y, objectType, brainType, *brainArgs):
         if not self._game:


### PR DESCRIPTION
This merge need the update in the pull request #6 

Fix a bug that cannot use create. (Not sure if the fix is the best modification)
Robots cannot be placed in water, or on top of another robot.
If the bot can't move into the water, then it can't place in water.

TODO: the bot can only move in the water cannot place in the land.
Suggestion: Need more states of waterAble, we can use 0 for land only, 1 for water only and 2 for amphibious.